### PR TITLE
add support for react version 16 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tiff",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "keywords": [
     "tiff",
     "react-tiff",
@@ -31,7 +31,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": ">=16.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
Simple fix to allow support for newer react versions without have to force install or ignore legacy peer deps

address #2 