### PR TITLE
Add Japanese support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const App = () => {
   return (
     <TIFFViewer
       tiff={tiffFile}
-      lang='en' // en | de | fr | es | tr
+      lang='en' // en | de | fr | es | tr | ja
       paginate='ltr' // bottom | ltr
       buttonColor='#141414'
       printable

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,13 @@ i18n.use(initReactI18next).init({
         Previous: 'Anterior',
         'Page of total': 'Página {{page}} de {{total}}'
       }
+    },
+    ja: {
+      translation: {
+        Next: '次へ',
+        Previous: '前へ',
+        'Page of total': '{{page}} / {{total}} ページ'
+      }
     }
   },
   lng: 'tr',


### PR DESCRIPTION
closes https://github.com/harundogdu/react-tiff/issues/5

## Description
Add Japanese support to i18n.

## Behavior
Texts for pagination are translated to Japanese by specifying "ja" to lang prop.
```js
<TIFFViewer
  tiff={tiffFile}
  lang='ja'
  paginate='ltr'
  buttonColor='#141414'
  printable
/>
```
## Screenshot
![React_TIFF_Viewer](https://github.com/harundogdu/react-tiff/assets/7753180/724102db-629f-4607-b9bb-3d945e4b12c0)