### PR TITLE
feat: add onLoad callback prop to TIFFViewer component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,12 +138,18 @@ export const TIFFViewer = forwardRef(function TiffFileViewer(
     onDocumentLoad(pages)
   }
 
-  async function displayTIFF(tiffUrl) {
+async function displayTIFF(tiffUrl) {
+  try {
     const response = await axios.get(tiffUrl, {
       responseType: 'arraybuffer'
     })
     imgLoaded({ target: { response: response.data } })
+  } finally {
+    if (typeof rest.onLoad === 'function') {
+      rest.onLoad()
+    }
   }
+}
 
   React.useEffect(() => {
     if (currentPage >= 0 && currentPage < pages.length) {
@@ -407,5 +413,6 @@ TIFFViewer.propTypes = {
   onDocumentLoad: PropTypes.func,
   currentPage: PropTypes.number,
   printable: PropTypes.bool,
-  zoomable: PropTypes.bool
+  zoomable: PropTypes.bool,
+  onLoad: PropTypes.func
 }


### PR DESCRIPTION
This PR adds a new optional `onLoad` callback prop to the `TIFFViewer` component.

### Purpose
Allows developers to handle events when a TIFF image has finished loading — for example, to hide a spinner or trigger another UI change.

### Example usage
```tsx
const [loading, setLoading] = useState(true);
<TIFFViewer file={file} onLoad={() => setLoading(false)} />
